### PR TITLE
🐛 fix: `convert_prefixes` incorrectly merges line breaks

### DIFF
--- a/src/gitmojify/mojify.py
+++ b/src/gitmojify/mojify.py
@@ -63,7 +63,7 @@ def gitmojify(
         first_word, *rest = message.split(maxsplit=1)
         if first_word.endswith(":"):
             first_word = first_word[:-1]
-        message = f"{first_word.lower()}: {' '.join(rest)}"
+        message = f"{first_word.lower()}: {''.join(rest)}"
     if any(map(message.startswith, allowed_prefixes or [])):
         return message
 

--- a/src/gitmojify/mojify.py
+++ b/src/gitmojify/mojify.py
@@ -60,7 +60,7 @@ def gitmojify(
         The gitmojified message.
     """
     if any(map(message.startswith, convert_prefixes or [])):
-        first_word, *rest = message.split()
+        first_word, *rest = message.split(maxsplit=1)
         if first_word.endswith(":"):
             first_word = first_word[:-1]
         message = f"{first_word.lower()}: {' '.join(rest)}"

--- a/tests/gitmojify/test_gitmojify.py
+++ b/tests/gitmojify/test_gitmojify.py
@@ -211,6 +211,42 @@ def test_gitmojify_with_convert_prefixes():
     assert result.startswith("✨")
 
 
+SUMMARY = "branch 'main' into branch 'dev'"
+DESCRIPTION = "This is a description."
+
+
+@pytest.mark.parametrize(
+    ["message_in", "message_out", "should_raise"],
+    [
+        (f"Merge {SUMMARY}", f"{GJ_MERGE} merge: {SUMMARY}", False),
+        (f"Merge: {SUMMARY}", f"{GJ_MERGE} merge: {SUMMARY}", False),
+        (f"merge {SUMMARY}", ..., True),
+        (f"merge: {SUMMARY}", f"{GJ_MERGE} merge: {SUMMARY}", False),
+        (
+            f"Merge {SUMMARY}\n\n{DESCRIPTION}",
+            f"{GJ_MERGE} merge: {SUMMARY}\n\n{DESCRIPTION}",
+            False,
+        ),
+        ("Merge", ..., True),
+        ("Merge: ", ..., True),
+        ("merge: ", ..., True),
+        # TODO: expected is f"{GJ_MERGE} merge: \n\n{DESCRIPTION}" and should_raise is True
+        (f"Merge \n\n{DESCRIPTION}", f"{GJ_MERGE} merge: {DESCRIPTION}", False),
+    ],
+)
+def test_gitmojify_with_convert_prefixes_merge(
+    message_in: str, message_out: str, should_raise: bool
+):
+    """Test gitmojify with convert_prefixes and the Merge prefix."""
+    if not should_raise:
+        result = mojify.gitmojify(message_in, convert_prefixes=["Merge"])
+        assert result == message_out
+    else:
+        with pytest.raises(ValueError) as exc_info:
+            mojify.gitmojify(message_in, convert_prefixes=["Merge"])
+        assert str(exc_info.value) == "invalid commit message"
+
+
 def test_gitmojify_with_allowed_prefixes():
     """Test gitmojify with allowed_prefixes."""
     message = "custom: special commit"

--- a/tests/gitmojify/test_gitmojify.py
+++ b/tests/gitmojify/test_gitmojify.py
@@ -242,9 +242,8 @@ def test_gitmojify_with_convert_prefixes_merge(
         result = mojify.gitmojify(message_in, convert_prefixes=["Merge"])
         assert result == message_out
     else:
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match="invalid commit message"):
             mojify.gitmojify(message_in, convert_prefixes=["Merge"])
-        assert str(exc_info.value) == "invalid commit message"
 
 
 def test_gitmojify_with_allowed_prefixes():


### PR DESCRIPTION
fix: https://github.com/ljnsn/cz-conventional-gitmoji/issues/208#issuecomment-2408847293

This is a simple test.

```py
convert_prefixes = ["Merge", "Revert", "Squash"]


def convert_prefix(message: str) -> str:
    if any(map(message.startswith, convert_prefixes or [])):
        first_word, *rest = message.split(maxsplit=1)
        if first_word.endswith(":"):
            first_word = first_word[:-1]
        message = f"{first_word.lower()}: {' '.join(rest)}"
        return message
    raise ValueError("No prefix to convert.")


input_message = "Merge: branch 'main' into feature/branch\n\nThis will be merged"
print(convert_prefix(input_message))
```