### PR TITLE
🐛 fix(mojify): don't split on newline and check if prefix is in conversion prefixes

### DIFF
--- a/src/gitmojify/mojify.py
+++ b/src/gitmojify/mojify.py
@@ -59,11 +59,13 @@ def gitmojify(
     Returns:
         The gitmojified message.
     """
-    if any(map(message.startswith, convert_prefixes or [])):
-        first_word, *rest = message.split(maxsplit=1)
+    convert_prefixes = convert_prefixes or []
+    if any(map(message.startswith, convert_prefixes)):
+        first_word, *rest = message.split(" ", maxsplit=1)
         if first_word.endswith(":"):
             first_word = first_word[:-1]
-        message = f"{first_word.lower()}: {''.join(rest)}"
+        if first_word in convert_prefixes:
+            message = f"{first_word.lower()}: {''.join(rest)}"
     if any(map(message.startswith, allowed_prefixes or [])):
         return message
 

--- a/tests/gitmojify/test_gitmojify.py
+++ b/tests/gitmojify/test_gitmojify.py
@@ -230,7 +230,7 @@ DESCRIPTION = "This is a description."
         ("Merge", ..., True),
         ("Merge: ", ..., True),
         ("merge: ", ..., True),
-        (f"Merge \n\n{DESCRIPTION}", f"{GJ_MERGE} merge: {DESCRIPTION}", True),
+        (f"Merge\n\n{DESCRIPTION}", f"{GJ_MERGE} merge: {DESCRIPTION}", True),
     ],
 )
 def test_gitmojify_with_convert_prefixes_merge(

--- a/tests/gitmojify/test_gitmojify.py
+++ b/tests/gitmojify/test_gitmojify.py
@@ -230,20 +230,19 @@ DESCRIPTION = "This is a description."
         ("Merge", ..., True),
         ("Merge: ", ..., True),
         ("merge: ", ..., True),
-        # TODO: expected is f"{GJ_MERGE} merge: \n\n{DESCRIPTION}" and should_raise is True
-        (f"Merge \n\n{DESCRIPTION}", f"{GJ_MERGE} merge: {DESCRIPTION}", False),
+        (f"Merge \n\n{DESCRIPTION}", f"{GJ_MERGE} merge: {DESCRIPTION}", True),
     ],
 )
 def test_gitmojify_with_convert_prefixes_merge(
     message_in: str, message_out: str, should_raise: bool
 ):
     """Test gitmojify with convert_prefixes and the Merge prefix."""
-    if not should_raise:
-        result = mojify.gitmojify(message_in, convert_prefixes=["Merge"])
-        assert result == message_out
-    else:
+    if should_raise:
         with pytest.raises(ValueError, match="invalid commit message"):
             mojify.gitmojify(message_in, convert_prefixes=["Merge"])
+    else:
+        result = mojify.gitmojify(message_in, convert_prefixes=["Merge"])
+        assert result == message_out
 
 
 def test_gitmojify_with_allowed_prefixes():


### PR DESCRIPTION
fixes #237