### PR TITLE
✨ feat: add use_github_emoji_code option

### DIFF
--- a/src/cz_gitmoji/main.py
+++ b/src/cz_gitmoji/main.py
@@ -16,6 +16,18 @@ from commitizen.question import CzQuestion
 
 from shared import utils
 from shared.gitmojis import GitmojiEnum as GJ  # noqa: N814
+from shared.settings import get_settings
+
+
+def _add_github_code_entries(type_map: dict) -> dict:
+    """Extend a change_type_map with GitHub code key variants."""
+    icon_to_code = {m.icon: m.code for m in utils.get_gitmojis()}
+    extra = {}
+    for key, value in type_map.items():
+        icon, _, type_name = key.partition(" ")
+        if icon in icon_to_code:
+            extra[f"{icon_to_code[icon]} {type_name}"] = value
+    return {**type_map, **extra}
 
 
 def parse_scope(text: str) -> str:
@@ -40,12 +52,12 @@ class CommitizenGitmojiCz(BaseCommitizen):
     # if none of these match, version will not be bumped (unless manually specified)
     bump_pattern = (
         rf"^((BREAKING[\-\ ]CHANGE"
-        rf"|{GJ.BOOM}? ?boom"
-        rf"|{GJ.FEAT}? ?feat"
-        rf"|{GJ.FIX}? ?fix"
-        rf"|{GJ.HOTFIX}? ?hotfix"
-        rf"|{GJ.REFACTOR}? +refactor"
-        rf"|{GJ.PERF}? ?perf)"
+        rf"|{GJ.BOOM}? ?boom|:boom: boom"
+        rf"|{GJ.FEAT}? ?feat|:sparkles: feat"
+        rf"|{GJ.FIX}? ?fix|:bug: fix"
+        rf"|{GJ.HOTFIX}? ?hotfix|:ambulance: hotfix"
+        rf"|{GJ.REFACTOR}? +refactor|:recycle: refactor"
+        rf"|{GJ.PERF}? ?perf|:zap: perf)"
         r"(\(.+\))?"  # scope
         r"!?):"  # breaking
     )
@@ -54,24 +66,24 @@ class CommitizenGitmojiCz(BaseCommitizen):
         (
             (r"^.+!$", MAJOR),
             (r"^BREAKING[\-\ ]CHANGE", MAJOR),
-            (rf"^{GJ.BOOM}? ?boom", MAJOR),
-            (rf"^{GJ.FEAT}? ?feat", MINOR),
-            (rf"^{GJ.FIX}? ?fix", PATCH),
-            (rf"^{GJ.HOTFIX}? ?hotfix", PATCH),
-            (rf"^{GJ.REFACTOR}? ?refactor", PATCH),
-            (rf"^{GJ.PERF}? ?perf", PATCH),
+            (rf"^({GJ.BOOM}? ?|:boom: )boom", MAJOR),
+            (rf"^({GJ.FEAT}? ?|:sparkles: )feat", MINOR),
+            (rf"^({GJ.FIX}? ?|:bug: )fix", PATCH),
+            (rf"^({GJ.HOTFIX}? ?|:ambulance: )hotfix", PATCH),
+            (rf"^({GJ.REFACTOR}? ?|:recycle: )refactor", PATCH),
+            (rf"^({GJ.PERF}? ?|:zap: )perf", PATCH),
         )
     )
     bump_map_major_version_zero = OrderedDict(
         (
             (r"^.+!$", MINOR),
             (r"^BREAKING[\-\ ]CHANGE", MINOR),
-            (rf"^{GJ.BOOM}? ?boom", MINOR),
-            (rf"^{GJ.FEAT}? ?feat", MINOR),
-            (rf"^{GJ.FIX}? ?fix", PATCH),
-            (rf"^{GJ.HOTFIX}? ?hotfix", PATCH),
-            (rf"^{GJ.REFACTOR}? ?refactor", PATCH),
-            (rf"^{GJ.PERF}? ?perf", PATCH),
+            (rf"^({GJ.BOOM}? ?|:boom: )boom", MINOR),
+            (rf"^({GJ.FEAT}? ?|:sparkles: )feat", MINOR),
+            (rf"^({GJ.FIX}? ?|:bug: )fix", PATCH),
+            (rf"^({GJ.HOTFIX}? ?|:ambulance: )hotfix", PATCH),
+            (rf"^({GJ.REFACTOR}? ?|:recycle: )refactor", PATCH),
+            (rf"^({GJ.PERF}? ?|:zap: )perf", PATCH),
         )
     )
     # parse information for generating the change log
@@ -81,10 +93,12 @@ class CommitizenGitmojiCz(BaseCommitizen):
     )
     # exclude from changelog
     changelog_pattern = (
-        rf"^(?!{GJ.INIT}? ?init)(?!{GJ.MERGE}? ?merge)(?!{GJ.BUMP}? ?bump).*"
+        rf"^(?!({GJ.INIT}? ?|:tada: )init)"
+        rf"(?!({GJ.MERGE}? ?|:twisted_rightwards_arrows: )merge)"
+        rf"(?!({GJ.BUMP}? ?|:bookmark: )bump).*"
     )
-    # map types to changelog sections
-    change_type_map = {
+    # map types to changelog sections (both emoji icon and GitHub code keys)
+    change_type_map = _add_github_code_entries({
         # boom
         f"{GJ.BOOM} boom": f"{GJ.BOOM} Boom",
         # features
@@ -188,7 +202,7 @@ class CommitizenGitmojiCz(BaseCommitizen):
         f"{GJ.CATCH} egg": f"{GJ.SECRET}{GJ.WIP}{GJ.ANALYTICS}{GJ.TYPO}{GJ.POOP}{GJ.EXTERNAL}{GJ.BEER}{GJ.TEXT}{GJ.EGG}{GJ.SEED}{GJ.FLAG}{GJ.CATCH}{GJ.HEALTH} Others",
         f"{GJ.HEALTH} health": f"{GJ.SECRET}{GJ.WIP}{GJ.ANALYTICS}{GJ.TYPO}{GJ.POOP}{GJ.EXTERNAL}{GJ.BEER}{GJ.TEXT}{GJ.EGG}{GJ.SEED}{GJ.FLAG}{GJ.CATCH}{GJ.HEALTH} Others",
         # None: init, bump, merge
-    }
+    })
     # order sections in changelog. all other sections are ordered alphabetically
     change_type_order = [
         f"{GJ.BOOM} Boom",
@@ -201,6 +215,10 @@ class CommitizenGitmojiCz(BaseCommitizen):
 
     def questions(self) -> List[CzQuestion]:
         """Return the questions to ask the user."""
+        try:
+            use_code = get_settings().use_github_emoji_code
+        except Exception:
+            use_code = False
         return [
             {
                 "type": "list",
@@ -208,8 +226,8 @@ class CommitizenGitmojiCz(BaseCommitizen):
                 "message": "Select the type of change you are committing",
                 "choices": [
                     {
-                        "value": moji.value,
-                        "name": moji.name,
+                        "value": moji.code_value if use_code else moji.value,
+                        "name": moji.code_name if use_code else moji.name,
                     }
                     for moji in utils.get_gitmojis()
                 ],

--- a/src/gitmojify/mojify.py
+++ b/src/gitmojify/mojify.py
@@ -42,6 +42,7 @@ def gitmojify(
     message: str,
     allowed_prefixes: Optional[List[str]] = None,
     convert_prefixes: Optional[List[str]] = None,
+    use_github_emoji_code: bool = False,
 ) -> str:
     """
     Gitmojify the commit message.
@@ -55,6 +56,8 @@ def gitmojify(
         allowed_prefixes: Prefixes that should not raise an error, even though
             they're not following conventional standard.
         convert_prefixes: Prefixes that should be converted to gitmoji format.
+        use_github_emoji_code: If True, prepend the GitHub emoji code (e.g.
+            ``:sparkles:``) instead of the emoji character.
 
     Returns:
         The gitmojified message.
@@ -77,8 +80,9 @@ def gitmojify(
     gtype = match.group("type_group")
     if " " in gtype:  # maybe do a better check?
         return message
-    icon = _grouped_gitmojis()[gtype].icon
-    return f"{icon} {message}"
+    moji = _grouped_gitmojis()[gtype]
+    emoji = moji.code if use_github_emoji_code else moji.icon
+    return f"{emoji} {message}"
 
 
 def _write(filepath: Optional[Path], message: str, encoding: str) -> None:
@@ -120,6 +124,7 @@ def run() -> None:
             _filter_comments(msg),
             args.allowed_prefixes or settings.allowed_prefixes,
             args.convert_prefixes or settings.convert_prefixes,
+            use_github_emoji_code=settings.use_github_emoji_code,
         ),
         settings.encoding,
     )

--- a/src/shared/model.py
+++ b/src/shared/model.py
@@ -19,3 +19,13 @@ class Gitmoji:
     def name(self) -> str:
         """The name property."""
         return f"{self.value}: {self.desc}"
+
+    @property
+    def code_value(self) -> str:
+        """Value using GitHub emoji code instead of icon."""
+        return f"{self.code} {self.type}"
+
+    @property
+    def code_name(self) -> str:
+        """Name using GitHub emoji code instead of icon."""
+        return f"{self.code_value}: {self.desc}"

--- a/src/shared/settings.py
+++ b/src/shared/settings.py
@@ -16,6 +16,7 @@ class MojiSettings:
     convert_prefixes: List[str] = attrs.field(factory=lambda: DEFAULT_CONVERT_PREFIXES)
     conventional_types_only: bool = False
     conventional_messages: bool = False
+    use_github_emoji_code: bool = False
     encoding: str
 
 

--- a/src/shared/utils.py
+++ b/src/shared/utils.py
@@ -1,3 +1,4 @@
+import re
 from typing import List
 
 from shared.model import Gitmoji
@@ -20,7 +21,10 @@ def get_gitmojis() -> List[Gitmoji]:
 
 def get_type_group_pattern() -> str:
     """Return the type group pattern."""
-    return "|".join([f"({moji.icon} {{1,2}})?{moji.type}" for moji in get_gitmojis()])
+    return "|".join([
+        f"({re.escape(moji.code)} |{moji.icon} {{1,2}})?{moji.type}"
+        for moji in get_gitmojis()
+    ])
 
 
 def get_pattern() -> str:

--- a/tests/cz_gitmoji/test_cz_gitmoji.py
+++ b/tests/cz_gitmoji/test_cz_gitmoji.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, Optional, Tuple
+from unittest import mock
 
 import pytest
 from commitizen.cz.exceptions import AnswerRequiredError
@@ -97,3 +98,27 @@ def test_process_commit(cz_gitmoji: CommitizenGitmojiCz) -> None:
     invalid_commit = "This is not a valid commit message"
     processed = cz_gitmoji.process_commit(invalid_commit)
     assert processed == ""
+
+
+def test_questions_use_github_emoji_code(cz_gitmoji: CommitizenGitmojiCz) -> None:
+    """Verify questions use GitHub code values when use_github_emoji_code=True."""
+    mock_settings = mock.MagicMock(use_github_emoji_code=True)
+    with mock.patch("cz_gitmoji.main.get_settings", return_value=mock_settings):
+        questions = cz_gitmoji.questions()
+
+    choices = questions[0]["choices"]  # type: ignore[typeddict-item]
+    assert len(choices) == len(mojis)
+    feat_choice = next(c for c in choices if "feat" in c["value"])
+    assert feat_choice["value"] == ":sparkles: feat"
+    assert feat_choice["name"].startswith(":sparkles: feat:")
+
+
+def test_questions_default_uses_emoji(cz_gitmoji: CommitizenGitmojiCz) -> None:
+    """Verify questions use emoji icon values by default."""
+    mock_settings = mock.MagicMock(use_github_emoji_code=False)
+    with mock.patch("cz_gitmoji.main.get_settings", return_value=mock_settings):
+        questions = cz_gitmoji.questions()
+
+    choices = questions[0]["choices"]  # type: ignore[typeddict-item]
+    feat_choice = next(c for c in choices if "feat" in c["value"])
+    assert feat_choice["value"] == "✨ feat"

--- a/tests/gitmojify/test_gitmojify.py
+++ b/tests/gitmojify/test_gitmojify.py
@@ -195,6 +195,7 @@ def test_run_with_options(tmp_path: Path):
                 allowed_prefixes=["custom"],
                 convert_prefixes=["Merge"],
                 encoding="utf-8",
+                use_github_emoji_code=False,
             ),
         ),
     ):
@@ -219,6 +220,7 @@ def test_run_with_options(tmp_path: Path):
                 allowed_prefixes=None,
                 convert_prefixes=["Merge"],
                 encoding="utf-8",
+                use_github_emoji_code=False,
             ),
         ),
     ):
@@ -288,4 +290,31 @@ def test_gitmojify_with_existing_gitmoji():
     """Test gitmojify with a message that already has a gitmoji."""
     message = "🐛 fix: resolve bug"
     result = mojify.gitmojify(message)
+    assert result == message
+
+
+@pytest.mark.parametrize(
+    ["message_in", "message_out"],
+    [
+        ("feat: some new feature", ":sparkles: feat: some new feature"),
+        ("docs(readme): add a section", ":memo: docs(readme): add a section"),
+        ("fix: resolve bug", ":bug: fix: resolve bug"),
+    ],
+)
+def test_gitmojify_github_code(message_in: str, message_out: str) -> None:
+    """Verify GitHub emoji codes are prepended when use_github_emoji_code=True."""
+    assert mojify.gitmojify(message_in, use_github_emoji_code=True) == message_out
+
+
+def test_gitmojify_github_code_already_present() -> None:
+    """Verify messages already prefixed with a GitHub code are returned as-is."""
+    message = ":sparkles: feat: already has code"
+    result = mojify.gitmojify(message, use_github_emoji_code=True)
+    assert result == message
+
+
+def test_gitmojify_github_code_emoji_already_present() -> None:
+    """Verify messages already prefixed with an emoji are returned as-is even when use_github_emoji_code=True."""
+    message = "✨ feat: already has emoji"
+    result = mojify.gitmojify(message, use_github_emoji_code=True)
     assert result == message


### PR DESCRIPTION
Closes #259. 

Adds a `use_github_emoji_code` setting that outputs GitHub emoji codes
(e.g. `:sparkles:`) instead of emoji characters (e.g. `✨`) in commit
messages.

